### PR TITLE
README Update: set completion of response verifaciton for read and derive commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ It is up to the crate user to send and receive the raw cktap APDU messages via N
 
 - [x] [status](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#status)
 - [x] [read](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#status) (messages)
-  - [ ] response verification
+  - [x] response verification
 - [x] [derive](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#derive) (messages)
-  - [ ] response verification
+  - [x] response verification
 - [x] [certs](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#certs)
 - [x] [new](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#new)
 - [x] [nfc](https://github.com/coinkite/coinkite-tap-proto/blob/master/docs/protocol.md#nfc)


### PR DESCRIPTION
### Description

This is an update to the README to show that the response
verification has been added to the code for the read and derive
commands.

### Notes to the reviewers

The verification for the two commands seem to be done in these
two code references

Read Trait:

https://github.com/notmandatory/rust-cktap/blob/d8258229ff080ce5adaeff65898bcc3846faa6d1/lib/src/commands.rs#L109

Derive:
- satscard:
https://github.com/notmandatory/rust-cktap/blob/d8258229ff080ce5adaeff65898bcc3846faa6d1/lib/src/lib.rs#L281
- tapsigner:
https://github.com/notmandatory/rust-cktap/blob/d8258229ff080ce5adaeff65898bcc3846faa6d1/lib/src/lib.rs#L132

